### PR TITLE
Set point size (Firefox fix)

### DIFF
--- a/Demo/Point-Cloud/vertex.glsl
+++ b/Demo/Point-Cloud/vertex.glsl
@@ -21,4 +21,5 @@ void main() {
 
     mat4 mvp = projection_matrix * view_matrix * model_matrix;
     gl_Position = mvp * vec4(vertex_position, 1);
+    gl_PointSize = 1.0;
 }


### PR DESCRIPTION
In Crome this code is OK
But in Firefox there are no points.
This parameter fixes it
It's really strange
Maybe Crome has some fallback parameter for gl_PointSize