### PR TITLE
fix: gl_PointSize must be declared for FF

### DIFF
--- a/09-Point-Cloud-Demo/public/main.js
+++ b/09-Point-Cloud-Demo/public/main.js
@@ -38,6 +38,7 @@ uniform mat4 matrix;
 void main() {
     vColor = vec3(position.xy, 1);
     gl_Position = matrix * vec4(position, 1);
+    gl_PointSize = 1.0;
 }
 `);
 gl.compileShader(vertexShader);


### PR DESCRIPTION
Hi! Added a line that makes it work on FF, and I bet other browsers. Credit should go to Antifurer X on youtube because he caught it with a comment.